### PR TITLE
Remove https:// in Client.php

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -12,7 +12,7 @@ class Client
 
     public function makeRequest($controller, $action, $parameters)
     {
-        $url = sprintf('https://%s/api/v1/%s/%s', $this->host, $controller, $action);
+        $url = sprintf('%s/api/v1/%s/%s', $this->host, $controller, $action);
 
         // Headers
         $headers = [


### PR DESCRIPTION
Https is already defined in `$client = new Postal\Client('https://postal.yourdomain.com', 'your-api-key');`