### PR TITLE
Added Hash to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ $message->htmlBody('<p>Hello world!</p>');
 
 // Add any custom headers
 $message->header('X-PHP-Test', 'value');
+$message->header('Hash', '');
 
 // Attach any files
 $message->attach('textmessage.txt', 'text/plain', 'Hello world!');


### PR DESCRIPTION
Added Hash value to custom headers. The parameter hash is needed to send it successfully.
Error: "headers" should be a "Hash" but is a "Array"