### PR TITLE
do not presume the existence of a code when throwing an error

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -32,7 +32,11 @@ class Client
             if ($json->status == 'success') {
                 return $json->data;
             } else {
-                throw new Error(sprintf('[%s] %s', $json->data->code, $json->data->message));
+                if (isset($json->data->code)) {
+                    throw new Error(sprintf('[%s] %s', $json->data->code, $json->data->message));
+                } else {
+                    throw new Error($json->data->message);
+                }
             }
         }
 


### PR DESCRIPTION
there are some errors in postal which return an error without a code being present but when the Client tries to throw the exception including the code, another error is generated which masks the original issue.