### PR TITLE
Refactor for RawMessage and endpoint correction

### DIFF
--- a/src/Send/RawMessage.php
+++ b/src/Send/RawMessage.php
@@ -7,36 +7,32 @@ namespace Postal\Send;
 class RawMessage
 {
     /**
-     * @var array{rcpt_to: array<string>, mail_from: string, data: string}
+     * @var array<string>
      */
-    public array $attributes;
+    public array $rcpt_to = [];
 
-    public function __construct()
-    {
-        $this->attributes = [
-            'rcpt_to' => [],
-            'mail_from' => '',
-            'data' => '',
-        ];
-    }
+    public ?string $mail_from = null;
+
+    public ?string $data = null;
+
 
     public function mailFrom(string $address): self
     {
-        $this->attributes['mail_from'] = $address;
+        $this->mail_from = $address;
 
         return $this;
     }
 
     public function rcptTo(string $address): self
     {
-        $this->attributes['rcpt_to'][] = $address;
+        $this->rcpt_to[] = $address;
 
         return $this;
     }
 
     public function data(string $data): self
     {
-        $this->attributes['data'] = base64_encode($data);
+        $this->data = base64_encode($data);
 
         return $this;
     }

--- a/src/SendService.php
+++ b/src/SendService.php
@@ -30,7 +30,7 @@ class SendService
     public function raw(RawMessage $message): Result
     {
         return $this->client->prepareResponse(
-            $this->client->getHttpClient()->post('send/message', [
+            $this->client->getHttpClient()->post('send/raw', [
                 'json' => $message,
             ]),
             Result::class,


### PR DESCRIPTION
https://github.com/postalserver/postal-php/issues/18

- Refactor the the RawMessage class to match the structure of the Message class
- Changed the SendService 'raw' endpoint to be 'send/raw' instead of 'send/message'